### PR TITLE
Add Server Override

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -122,6 +122,8 @@ function secureServerEvent(resource, player, token)
 	local _source = player
 	if resourceTokens[resource] == nil then
 		return true
+	elseif _source = "" then -- If the request came from the server, then no need to authenticate the token
+		return true 
 	else
 		if Config.VerboseServer then
 			print("Validating token for " .. tostring(resource) .. " for Player ID " .. tostring(_source) .. ". Provided: " .. tostring(token) .. " Stored: " .. tostring(resourceTokens[resource]))


### PR DESCRIPTION
Adding in this single IF statement allows the server to call a secured server event without having to create a non-tokenized version.

Essentially: If server is the requestor - return true
If not: Check token