### PR TITLE
Fixing same tokens being generated sometimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,19 @@ client_script '@salty_tokenizer/init.lua'
 Note: If you implemented salty_tokenizer prior to the `init.lua` script being released, it will continue to function normally and no changed need to be made.
 
 ## Client
-Once the token is received, it can be passed along with a server event to be validated on the server-side.
+**Once the token is received**, it can be passed along with a server event to be validated on the server-side:
 ```lua
 TriggerServerEvent('anticheat-testing:testEvent', securityToken)
+```
+
+It's recommended to make sure that the client has the token to prevent false positives, like so:
+```lua
+Citizen.CreateThread(function()
+	while securityToken == nil do
+		Citizen.Wait(100)
+	end
+	TriggerServerEvent('anticheat-testing:testEvent', securityToken)
+end)
 ```
 
 ## Server

--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ Add security tokens to FiveM server events that are accessible from the client i
 * Players that trigger a server event without a valid security token are kicked from the game.
 
 # Installation
-There are no dependencies for this resource. The configuration file is set to generate a 24 character alphanumerical security token. If this is insufficient, the character set and length can be adjusted. In addition, the message a player gets if they are kicked due to an invalid token may be adjusted in the configuration file.
+* Install [yarn](https://github.com/citizenfx/cfx-server-data) (Can be found in `/resources/[system]/[builders]/yarn`)
+* Configure `salty_tokenizer` using the `config.lua` file.
+* Add `ensure salty_tokenizer` to your server config.
+* Restart your server.
 
 # Usage
-The security token is stored in a variable named `securityToken` on the client side in each resource. In order to retreive the security token for a given resource, you must include the `init.lua` script in your resource's `__resource.lua` file. The `init.lua` script must be included as both a server and client script:
+The security token is stored in a variable named `securityToken` on the client side in each resource. In order to retreive the security token for a given resource, you must include the `init.lua` script in your resource's `__resource.lua` or `fxmanifest.lua` file. The `init.lua` script must be included as both a server and client script:
 ```lua
 server_script '@salty_tokenizer/init.lua'
 client_script '@salty_tokenizer/init.lua'

--- a/config.lua
+++ b/config.lua
@@ -8,29 +8,6 @@ Config.VerboseClient = false
 Config.VerboseServer = false
 
 --[[
-	Define the length of the generated token
---]]
-Config.TokenLength = 24
-
---[[
-	Define the character set to be used in generation
-	%a%d = all capital and lowercase letters and digits
-	Syntax:
-		.	all characters
-		%a	letters
-		%c	control characters
-		%d	digits
-		%l	lower case letters
-		%p	punctuation characters
-		%s	space characters
-		%u	upper case letters
-		%w	alphanumeric characters
-		%x	hexadecimal digits
-		%z	the character with representation 0
---]]
-Config.TokenCharset = "%a%d"
-
---[[
 	Adjust the delay between when the client deploys the listeners and
 	when the server sends the information.
 	250 seems like a sweet spot here, but it can be reduced or increased if desired.

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,12 +3,15 @@ game 'gta5'
 
 description 'Add security tokens to server events.'
 
+dependency "yarn"
+
 client_scripts {
 	'config.lua',
 	'client.lua'
 }
 
 server_scripts {
+	'uuid.js',
 	'config.lua',
 	'server.lua'
 }
@@ -18,6 +21,7 @@ exports {
 }
 
 server_exports {
+	'generateToken',
 	'setupServerResource',
 	'secureServerEvent',
 	'getResourceToken'

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+	"dependencies": {
+		"uuid": "^8.3.2"
+	}
+}

--- a/uuid.js
+++ b/uuid.js
@@ -1,0 +1,5 @@
+const { v4: uuidv4 } = require('uuid');
+
+exports("generateToken", () => {
+	return uuidv4()
+})


### PR DESCRIPTION
When resources would start up quick enough you'd run into a problem where the tokens and event names would be the same without `salty_tokenizer` noticing. So I've asked around and someone suggested a solution, which does work for me. I've tested the fix a couple times now and I have personally not noticed a drop in load time, but every server is different.

Here's two examples of what I mean with same tokens (using verbose server to print those out):

Without the fix applied:
```log
[script:salty_tokeniz] > > > S A L T Y _ T O K E N I Z E R  < < <
[script:salty_tokeniz] Generated token for resource resource_one: MuKNLDXaOVt6CrHVmLZEGkLQ
[script:salty_tokeniz] Generated token for resource resource_two: MuKNLDXaOVt6CrHVmLZEGkLQ
[      script:hardcap] Connecting: Puntherline
[script:salty_tokeniz] Obfuscated Event for Player ID 1: Original - resource_two Obfuscated - q0QkVKT35uWEObedLZUmkm4s
[script:salty_tokeniz] Obfuscated Event for Player ID 1: Original - resource_one Obfuscated - q0QkVKT35uWEObedLZUmkm4s
[script:salty_tokeniz] Player ID 1 loaded.
[script:salty_tokeniz] Sending token for resource_two (Event: q0QkVKT35uWEObedLZUmkm4s Token: MuKNLDXaOVt6CrHVmLZEGkLQ) to Player ID 1.
[script:salty_tokeniz] Sending token for resource_one (Event: q0QkVKT35uWEObedLZUmkm4s Token: MuKNLDXaOVt6CrHVmLZEGkLQ) to Player ID 1.
[script:salty_tokeniz] Validating token for resource_two for Player ID 1. Provided: MuKNLDXaOVt6CrHVmLZEGkLQ Stored: MuKNLDXaOVt6CrHVmLZEGkLQ
[  script:resource_two] Authenticated
```

With the fix applied:
```log
[script:salty_tokeniz] > > > S A L T Y _ T O K E N I Z E R  < < <
[script:salty_tokeniz] Generated token for resource resource_one: 94bf94fb-b29d-43b0-b1b1-ddd457a0c26a
[script:salty_tokeniz] Generated token for resource resource_two: 30280808-56a9-4e97-aeb9-301f53c0da3a
[      script:hardcap] Connecting: Puntherline
[script:salty_tokeniz] Obfuscated Event for Player ID 1: Original - resource_two Obfuscated - b8d8f81f-9f5d-4f09-8083-0001f156ef11
[script:salty_tokeniz] Obfuscated Event for Player ID 1: Original - resource_one Obfuscated - e94b8030-7182-4ddc-b423-97478005c1fc
[script:salty_tokeniz] Player ID 1 loaded.
[script:salty_tokeniz] Sending token for resource_two (Event: b8d8f81f-9f5d-4f09-8083-0001f156ef11 Token: 30280808-56a9-4e97-aeb9-301f53c0da3a) to Player ID 1.
[script:salty_tokeniz] Sending token for resource_one (Event: e94b8030-7182-4ddc-b423-97478005c1fc Token: 94bf94fb-b29d-43b0-b1b1-ddd457a0c26a) to Player ID 1.
[script:salty_tokeniz] Validating token for resource_two for Player ID 1. Provided: 30280808-56a9-4e97-aeb9-301f53c0da3a Stored: 30280808-56a9-4e97-aeb9-301f53c0da3a
[  script:resource_two] Authenticated
```

Server owners lose their custom charset and custom token length but get way better pseudo-random strings.